### PR TITLE
fixed a wrong  & the malformed normal_texture entry

### DIFF
--- a/spec/u3m_schema.json
+++ b/spec/u3m_schema.json
@@ -357,7 +357,7 @@
                     "$ref": "#/definitions/color_rgb"
                 },
                 "texture": {
-                    "#ref": "#/definitions/color_texture"
+                    "$ref": "#/definitions/color_texture"
                 }
             },
             "additionalProperties": false,
@@ -384,8 +384,7 @@
             },
             "additionalProperties": false,
             "required": [
-                "factor",
-                "offset",
+                "scale",
                 "image"
             ]
         },


### PR DESCRIPTION
fixed a typo and a copy and paste error in the schema

now quicktype.io can parse the schema