### PR TITLE
Add rule for required objects from u3m_additional_spec_u3m.txt to the schema

### DIFF
--- a/u3m1.1/spec/u3m_schema.json
+++ b/u3m1.1/spec/u3m_schema.json
@@ -844,6 +844,22 @@
                     "$ref": "#/definitions/metadata"
                 }
             },
+            "not": {
+                "properties": {
+                    "front": {
+                        "type": "null"
+                    },
+                    "back": {
+                        "type": "null"
+                    },
+                    "side": {
+                        "type": "null"
+                    },
+                    "physics": {
+                        "type": "null"
+                    }
+                }
+            },
             "additionalProperties": false,
             "required": [
                 "name",


### PR DESCRIPTION
rule: "A valid U3M must contain at least one visual ("front", "back" or "side") or physics, a file with neither physics nor visuals is malformed"