### PR TITLE
Upgrade u3mschema version

### DIFF
--- a/u3m1.0/u3m_schema_version1.json
+++ b/u3m1.0/u3m_schema_version1.json
@@ -1,304 +1,300 @@
 {
-  "$schema":"http://json-schema.org/draft-04/schema#",
-  "definitions":{
-    "color_rgb":{
-      "type":"object",
-      "properties":{
-        "r":{
-          "type":"number",
-          "minimum":0,
-          "maximum":1
-        },
-        "g":{
-          "type":"number",
-          "minimum":0,
-          "maximum":1
-        },
-        "b":{
-          "type":"number",
-          "minimum":0,
-          "maximum":1
-        }
-      },
-      "additionalProperties":false,
-      "required":[
-        "r",
-        "g",
-        "b"
-      ]
-    },
-    "image":{
-      "type":"object",
-      "properties":{
-        "width":{
-          "type":"number",
-          "minimum":0
-        },
-        "height":{
-          "type":"number",
-          "minimum":0
-        },
-        "dpi":{
-          "type":"number",
-          "minimum":0
-        },
-        "path":{
-          "description":"relative path to the image",
-          "type":"string"
-        },
-        "repeat":{
-          "type":"object",
-          "properties":{
-            "rotation":{
-              "type":"number"
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "color_rgb": {
+            "type": "object",
+            "properties": {
+                "r": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "g": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "b": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
             },
-            "mode":{
-              "description":"normal - wrap_x + wrap_y, mirror_x - mirror_x + wrap_y, mirror_y - wrap_x + mirror_y, mirror_xy - mirror_x + mirror_y",
-              "enum":[
-                "normal",
-                "mirror_x",
-                "mirror_y",
-                "mirror_xy"
-              ]
-            }
-          },
-          "additionalProperties":false,
-          "required":[
-            "rotation",
-            "mode"
+            "additionalProperties": false,
+            "required": [
+                "r",
+                "g",
+                "b"
+            ]
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "width": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "height": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "dpi": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "path": {
+                    "description": "relative path to the image",
+                    "type": "string"
+                },
+                "repeat": {
+                    "type": "object",
+                    "properties": {
+                        "rotation": {
+                            "type": "number"
+                        },
+                        "mode": {
+                            "description": "normal - wrap_x + wrap_y, mirror_x - mirror_x + wrap_y, mirror_y - wrap_x + mirror_y, mirror_xy - mirror_x + mirror_y",
+                            "enum": [
+                                "normal",
+                                "mirror_x",
+                                "mirror_y",
+                                "mirror_xy"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "rotation",
+                        "mode"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "repeat",
+                "dpi",
+                "path",
+                "width",
+                "height"
+            ]
+        },
+        "texture_and_color": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "constant": {
+                    "$ref": "#/definitions/color_rgb"
+                },
+                "texture": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "mode": {
+                            "enum": [
+                                "add",
+                                "subtract",
+                                "multiply",
+                                "divide",
+                                "max",
+                                "min",
+                                "overlay"
+                            ]
+                        },
+                        "factor": {
+                            "$ref": "#/definitions/color_rgb"
+                        },
+                        "image": {
+                            "$ref": "#/definitions/image"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "factor",
+                        "mode",
+                        "image"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "constant",
+                "texture"
+            ]
+        },
+        "texture_and_number": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "constant": {
+                    "type": "number"
+                },
+                "texture": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "factor": {
+                            "type": "number"
+                        },
+                        "offset": {
+                            "type": "number"
+                        },
+                        "image": {
+                            "$ref": "#/definitions/image"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "factor",
+                        "offset",
+                        "image"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "constant",
+                "texture"
+            ]
+        },
+        "visualisation": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "alpha": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "anisotropy_value": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "anisotropy_rotation": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "clearcoat_value": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "clearcoat_normal": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "clearcoat_roughness": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "ior": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "metalness": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "normal": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "displacement": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "roughness": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "sheen_value": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "sheen_tint": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "specular_value": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "specular_tint": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "subsurface_radius": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "subsurface_value": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "transmission": {
+                    "$ref": "#/definitions/texture_and_number"
+                },
+                "basecolor": {
+                    "$ref": "#/definitions/texture_and_color"
+                },
+                "subsurface_color": {
+                    "$ref": "#/definitions/texture_and_color"
+                },
+                "shader": {
+                    "const": "principled"
+                }
+            },
+            "additionalProperties": false,
+            "minProperties": 21
+        }
+    },
+    "type": "object",
+    "properties": {
+        "schema": {
+            "const": "1.0"
+        },
+        "material": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "description": "UUID4 represented as string with or without {}",
+                    "type": "string",
+                    "pattern": "^(\\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\\}{0,1})$"
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "description": {
+                    "type": "string"
+                },
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "front": {
+                    "$ref": "#/definitions/visualisation"
+                },
+                "back": {
+                    "$ref": "#/definitions/visualisation"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "name",
+                "id",
+                "created",
+                "modified",
+                "front",
+                "back",
+                "description"
+            ]
+        },
+        "custom": {
+            "type": [
+                "object",
+                "null"
             ]
         }
-      },
-      "additionalProperties":false,
-      "required":[
-        "repeat",
-        "dpi",
-        "path",
-        "width",
-        "height"
-      ]
     },
-    "texture_and_color":{
-      "type":[
-        "object",
-        "null"
-      ],
-      "properties":{
-        "constant":{
-          "$ref":"#/definitions/color_rgb"
-        },
-        "texture":{
-          "type":[
-            "object",
-            "null"
-          ],
-          "properties":{
-            "mode":{
-              "enum":[
-                "add",
-                "subtract",
-                "multiply",
-                "divide",
-                "max",
-                "min",
-                "overlay"
-              ]
-            },
-            "factor":{
-              "$ref":"#/definitions/color_rgb"
-            },
-            "image":{
-              "$ref":"#/definitions/image"
-            }
-          },
-          "additionalProperties":false,
-          "required":[
-            "factor",
-            "mode",
-            "image"
-          ]
-        }
-      },
-      "additionalProperties":false,
-      "required":[
-        "constant",
-        "texture"
-      ]
-    },
-    "texture_and_number":{
-      "type":[
-        "object",
-        "null"
-      ],
-      "properties":{
-        "constant":{
-          "type":"number"
-        },
-        "texture":{
-          "type":[
-            "object",
-            "null"
-          ],
-          "properties":{
-            "factor":{
-              "type":"number"
-            },
-            "offset":{
-              "type":"number"
-            },
-            "image":{
-              "$ref":"#/definitions/image"
-            }
-          },
-          "additionalProperties":false,
-          "required":[
-            "factor",
-            "offset",
-            "image"
-          ]
-        }
-      },
-      "additionalProperties":false,
-      "required":[
-        "constant",
-        "texture"
-      ]
-    },
-    "visualisation":{
-      "type":[
-        "object",
-        "null"
-      ],
-      "properties":{
-        "alpha":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "anisotropy_value":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "anisotropy_rotation":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "clearcoat_value":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "clearcoat_normal":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "clearcoat_roughness":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "ior":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "metalness":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "normal":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "displacement":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "roughness":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "sheen_value":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "sheen_tint":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "specular_value":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "specular_tint":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "subsurface_radius":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "subsurface_value":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "transmission":{
-          "$ref":"#/definitions/texture_and_number"
-        },
-        "basecolor":{
-          "$ref":"#/definitions/texture_and_color"
-        },
-        "subsurface_color":{
-          "$ref":"#/definitions/texture_and_color"
-        },
-        "shader":{
-          "enum":[
-                "principled"
-              ]
-        }
-      },
-      "additionalProperties":false,
-      "minProperties":21
-    }
-  },
-  "type":"object",
-  "properties":{
-    "schema":{
-      "enum":[
-        "1.0"
-        ]
-    },
-    "material":{
-      "type":"object",
-      "properties":{
-        "id":{
-          "description":"UUID4 represented as string with or without {}",
-          "type":"string",
-          "pattern":"^(\\{{0,1}([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F]){12}\\}{0,1})$"
-        },
-        "name":{
-          "type":"string",
-          "minLength":1
-        },
-        "description":{
-          "type":"string"
-        },
-        "created":{
-          "type":"string",
-          "format":"date-time"
-        },
-        "modified":{
-          "type":"string",
-          "format":"date-time"
-        },
-        "front":{
-          "$ref":"#/definitions/visualisation"
-        },
-        "back":{
-          "$ref":"#/definitions/visualisation"
-        }
-      },
-      "additionalProperties":false,
-      "required":[
-        "name",
-        "id",
-        "created",
-        "modified",
-        "front",
-        "back",
-        "description"
-      ]
-    },
-    "custom":{
-      "type":[
-        "object",
-        "null"
-      ]
-    }
-  },
-  "additionalProperties":false,
-  "required":[
-    "schema",
-    "material",
-    "custom"
-  ]
+    "additionalProperties": false,
+    "required": [
+        "schema",
+        "material",
+        "custom"
+    ]
 }

--- a/u3m1.1/physics/physics_schema.json
+++ b/u3m1.1/physics/physics_schema.json
@@ -1,220 +1,217 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "definitions": {
-    "hwSerialNumber": {
-      "description": "Hardware serial number.",
-      "type": "integer"
-    },
-    "hwVersion": {
-      "description": "Hardware version.",
-      "type": "integer"
-    },
-    "testVersion": {
-      "description": "Version used for this test.",
-      "type": "integer"
-    },
-    "time": {
-      "description": "Time stamp in time_t (time_t base time is the number of seconds from midnight, January 1, 1970).",
-      "type": "integer"
-    },
-    "width": {
-      "description": "The width of the measured fabric.",
-      "type": "integer"
-    },
-    "length": {
-      "description": "The length of the measured fabric.",
-      "type": "number"
-    },
-    "samplesTree": {
-      "description": "The measurement's raw data: pairs of distance and force.",
-      "type": "array",
-      "items": {
-        "type": "array",
-        "items": {
-          "type": "number"
-        }
-      }
-    },
-    "measurementPart": {
-      "type": "object",
-      "properties": {
-        "freq": {
-          "description": "The sampling rate of the FAB machine.",
-          "type": "integer"
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "hwSerialNumber": {
+            "description": "Hardware serial number.",
+            "type": "integer"
+        },
+        "hwVersion": {
+            "description": "Hardware version.",
+            "type": "integer"
+        },
+        "testVersion": {
+            "description": "Version used for this test.",
+            "type": "integer"
+        },
+        "time": {
+            "description": "Time stamp in time_t (time_t base time is the number of seconds from midnight, January 1, 1970).",
+            "type": "integer"
         },
         "width": {
-          "$ref": "#/definitions/width"
+            "description": "The width of the measured fabric.",
+            "type": "integer"
         },
         "length": {
-          "$ref": "#/definitions/length"
-        },        
-        "samplesTree": {
-          "$ref": "#/definitions/samplesTree"
-        },
-        "hwSerialNumber": {
-          "$ref": "#/definitions/hwSerialNumber"
-        },
-        "hwVersion": {
-          "$ref": "#/definitions/hwVersion"
-        },
-        "testVersion": {
-          "$ref": "#/definitions/testVersion"
-        },
-        "time": {
-          "$ref": "#/definitions/time"
-        }
-      },
-      "required": [
-        "freq",
-        "width",
-        "length",
-        "samplesTree",
-        "hwSerialNumber",
-        "hwVersion",
-        "testVersion",
-        "time"
-      ]
-    },
-    "measurement": {
-      "type": "object",
-      "properties": {
-        "D1": {
-          "description": "Downward bend measure at 2 cm distance.",
-          "$ref": "#/definitions/measurementPart"
-        },
-        "D2": {
-          "description": "Downward bend measure at 8 cm distance.",
-          "$ref": "#/definitions/measurementPart"
-        },
-        "S1": {
-          "description": "Stretch measure at 2 cm distance.",
-          "$ref": "#/definitions/measurementPart"
-        },
-        "S2": {
-          "description": "Stretch measure at 8 cm distance.",
-          "$ref": "#/definitions/measurementPart"
-        },
-        "U1": {
-          "description": "Upward bend measure at 2 cm distance.",
-          "$ref": "#/definitions/measurementPart"
-        },
-        "hwSerialNumber": {
-          "$ref": "#/definitions/hwSerialNumber"
-        },
-        "hwVersion": {
-          "$ref": "#/definitions/hwVersion"
-        },
-        "testVersion": {
-          "$ref": "#/definitions/testVersion"
-        },
-        "time": {
-          "$ref": "#/definitions/time"
-        },
-        "width": {
-          "$ref": "#/definitions/width"
-        }
-      },
-      "required": [
-        "D1",
-        "D2",
-        "S1",
-        "S2",
-        "U1"
-      ]
-    },
-    "thicknessMeasurement": {
-      "type": "object",
-      "properties": {
-        "freq": {
-          "description": "The sampling rate of the FAB machine.",
-          "type": "integer"
-        },
-        "width": {
-          "$ref": "#/definitions/width"
+            "description": "The length of the measured fabric.",
+            "type": "number"
         },
         "samplesTree": {
-          "$ref": "#/definitions/samplesTree"
+            "description": "The measurement's raw data: pairs of distance and force.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number"
+                }
+            }
         },
-        "hwSerialNumber": {
-          "$ref": "#/definitions/hwSerialNumber"
+        "measurementPart": {
+            "type": "object",
+            "properties": {
+                "freq": {
+                    "description": "The sampling rate of the FAB machine.",
+                    "type": "integer"
+                },
+                "width": {
+                    "$ref": "#/definitions/width"
+                },
+                "length": {
+                    "$ref": "#/definitions/length"
+                },
+                "samplesTree": {
+                    "$ref": "#/definitions/samplesTree"
+                },
+                "hwSerialNumber": {
+                    "$ref": "#/definitions/hwSerialNumber"
+                },
+                "hwVersion": {
+                    "$ref": "#/definitions/hwVersion"
+                },
+                "testVersion": {
+                    "$ref": "#/definitions/testVersion"
+                },
+                "time": {
+                    "$ref": "#/definitions/time"
+                }
+            },
+            "required": [
+                "freq",
+                "width",
+                "length",
+                "samplesTree",
+                "hwSerialNumber",
+                "hwVersion",
+                "testVersion",
+                "time"
+            ]
         },
-        "hwVersion": {
-          "$ref": "#/definitions/hwVersion"
+        "measurement": {
+            "type": "object",
+            "properties": {
+                "D1": {
+                    "description": "Downward bend measure at 2 cm distance.",
+                    "$ref": "#/definitions/measurementPart"
+                },
+                "D2": {
+                    "description": "Downward bend measure at 8 cm distance.",
+                    "$ref": "#/definitions/measurementPart"
+                },
+                "S1": {
+                    "description": "Stretch measure at 2 cm distance.",
+                    "$ref": "#/definitions/measurementPart"
+                },
+                "S2": {
+                    "description": "Stretch measure at 8 cm distance.",
+                    "$ref": "#/definitions/measurementPart"
+                },
+                "U1": {
+                    "description": "Upward bend measure at 2 cm distance.",
+                    "$ref": "#/definitions/measurementPart"
+                },
+                "hwSerialNumber": {
+                    "$ref": "#/definitions/hwSerialNumber"
+                },
+                "hwVersion": {
+                    "$ref": "#/definitions/hwVersion"
+                },
+                "testVersion": {
+                    "$ref": "#/definitions/testVersion"
+                },
+                "time": {
+                    "$ref": "#/definitions/time"
+                },
+                "width": {
+                    "$ref": "#/definitions/width"
+                }
+            },
+            "required": [
+                "D1",
+                "D2",
+                "S1",
+                "S2",
+                "U1"
+            ]
         },
-        "testVersion": {
-          "$ref": "#/definitions/testVersion"
-        },
-        "time": {
-          "$ref": "#/definitions/time"
+        "thicknessMeasurement": {
+            "type": "object",
+            "properties": {
+                "freq": {
+                    "description": "The sampling rate of the FAB machine.",
+                    "type": "integer"
+                },
+                "width": {
+                    "$ref": "#/definitions/width"
+                },
+                "samplesTree": {
+                    "$ref": "#/definitions/samplesTree"
+                },
+                "hwSerialNumber": {
+                    "$ref": "#/definitions/hwSerialNumber"
+                },
+                "hwVersion": {
+                    "$ref": "#/definitions/hwVersion"
+                },
+                "testVersion": {
+                    "$ref": "#/definitions/testVersion"
+                },
+                "time": {
+                    "$ref": "#/definitions/time"
+                }
+            },
+            "required": [
+                "freq",
+                "width",
+                "samplesTree",
+                "hwSerialNumber",
+                "hwVersion",
+                "testVersion",
+                "time"
+            ]
         }
-      },
-      "required": [
-        "freq",
-        "width",
-        "samplesTree",
-        "hwSerialNumber",
-        "hwVersion",
-        "testVersion",
-        "time"
-      ]
-    }
-  },
-
-  "type": "object",
-  "properties": {
-    "raw_data": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "properties": {
-        "B": {
-          "description": "Biased Grainline.",
-          "$ref": "#/definitions/measurement"
+    },
+    "type": "object",
+    "properties": {
+        "raw_data": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "B": {
+                    "description": "Biased Grainline.",
+                    "$ref": "#/definitions/measurement"
+                },
+                "L": {
+                    "description": "Length Grainline.",
+                    "$ref": "#/definitions/measurement"
+                },
+                "T": {
+                    "description": "Thickness",
+                    "$ref": "#/definitions/thicknessMeasurement"
+                },
+                "W": {
+                    "description": "Width Grainline.",
+                    "$ref": "#/definitions/measurement"
+                },
+                "M": {
+                    "description": "Mass (The mass density of the fabric).",
+                    "type": "number"
+                }
+            },
+            "additionalProperties": true,
+            "required": [
+                "B",
+                "L",
+                "T",
+                "W",
+                "M"
+            ]
         },
-        "L": {
-          "description": "Length Grainline.",
-          "$ref": "#/definitions/measurement"
+        "schema": {
+            "type": "string",
+            "const": "1.1"
         },
-        "T": {
-          "description": "Thickness",
-          "$ref": "#/definitions/thicknessMeasurement"
-        },
-        "W": {
-          "description": "Width Grainline.",
-          "$ref": "#/definitions/measurement"
-        },
-        "M": {
-          "description": "Mass (The mass density of the fabric).",
-          "type": "number"
+        "custom": {
+            "type": [
+                "object",
+                "null"
+            ]
         }
-      },
-      "additionalProperties": true,
-      "required": [
-        "B",
-        "L",
-        "T",
-        "W",
-        "M"
-      ]
     },
-    "schema": {
-      "type": "string",
-      "enum": [
-        "1.1"
-      ]
-    },
-    "custom": {
-      "type": [
-        "object",
-        "null"
-      ]
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "raw_data",
-    "schema",
-    "custom"
-  ]
+    "additionalProperties": false,
+    "required": [
+        "raw_data",
+        "schema",
+        "custom"
+    ]
 }

--- a/u3m1.1/spec/u3m_additional_spec.txt
+++ b/u3m1.1/spec/u3m_additional_spec.txt
@@ -74,26 +74,26 @@ paths:
             LPT[1-9]
 
     forbid directory changers (for security reasons)
-        \.|\.\.|\~
+        \.|\.\.|~
 
     forbid environment variables (for security reasons)
-        [^\$\%]
+        [^\$%]
 
     -> leads to the following regex for a file or directory name:
-        - must not match ^(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))$
-        - must match     ^([^\x00-\x1F<>:"\/\\|\$\%]{0,254}[^\x00-\x1F<>:"\/\\|\$\%\.\x20|])$
+        - must not match ^(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))$
+        - must match     ^([^\x00-\x1F<>:"\/\\|\$%]{0,254}[^\x00-\x1F<>:"\/\\|\$%\.\x20|])$
 
     regexes:
-    -> #dir: (?!(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$\%]{0,254}[^\x00-\x1F<>:"\/\\|\$\%\.\x20|]\/)
-    -> #file: (?!(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\..*)?))$)([^\x00-\x1F<>:"\/\\|]{0,254}[^\x00-\x1F<>:"\/\\\.\x20|]$)
+    -> #dir: (?!(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$%]{0,254}[^\x00-\x1F<>:"\/\\|\$%\.\x20|]\/)
+    -> #file: (?!(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\..*)?))$)([^\x00-\x1F<>:"\/\\|]{0,254}[^\x00-\x1F<>:"\/\\\.\x20|]$)
 
     -> directory-path: ^(#dir/)+
     -> file-path: ^(#dir/)*#file$
 
     regex for files:
-    ^((?!(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$\%]{0,254}[^\x00-\x1F<>:"\/\\|\$\%\.\x20|]\/))*(?!(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\..*)?))$)([^\x00-\x1F<>:"\/\\|]{0,254}[^\x00-\x1F<>:"\/\\\.\x20|]$)$
+    ^((?!(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$%]{0,254}[^\x00-\x1F<>:"\/\\|\$%\.\x20|]\/))*(?!(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\..*)?))$)([^\x00-\x1F<>:"\/\\|]{0,254}[^\x00-\x1F<>:"\/\\\.\x20|]$)$
     see https://www.regextester.com/?fam=115492
     
     regex for directories:
-    ^((?!(\.\.|\.|\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$\%]{0,254}[^\x00-\x1F<>:"\/\\|\$\%\.\x20|]\/))+$
+    ^((?!(\.\.|\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\.[^\/]*)?))\/)([^\x00-\x1F<>:"\/\\|\$%]{0,254}[^\x00-\x1F<>:"\/\\|\$%\.\x20|]\/))+$
     see 

--- a/u3m1.1/spec/u3m_schema.json
+++ b/u3m1.1/spec/u3m_schema.json
@@ -39,13 +39,13 @@
         "relative_file_path": {
             "description": "relative path (from this file) to an other file",
             "type": "string",
-            "pattern": "^((?!(\\.\\.|\\.|\\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\.[^\\/]*)?))\\/)([^\\x00-\\x1F<>:\"\\/\\\\|\\$\\%]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\|\\$\\%\\.\\x20|]\\/))*(?!(\\.\\.|\\.|\\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\..*)?))$)([^\\x00-\\x1F<>:\"\\/\\\\|]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\\\.\\x20|]$)$"
+            "pattern": "^((?!(\\.\\.|\\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\.[^\\/]*)?))\\/)([^\\x00-\\x1F<>:\"\\/\\\\|\\$%]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\|\\$%\\.\\x20|]\\/))*(?!(\\.\\.|\\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\..*)?))$)([^\\x00-\\x1F<>:\"\\/\\\\|]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\\\.\\x20|]$)$"
         },
         "optional_relative_file_path": {
             "description": "relative path (from this file) to an other file or \"null\" if empty",
             "type": "string",
             "default": "null",
-            "pattern": "^((null)|(((?!(\\.\\.|\\.|\\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\.[^\\/]*)?))\\/)([^\\x00-\\x1F<>:\"\\/\\\\|\\$\\%]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\|\\$\\%\\.\\x20|]\\/))*(?!(\\.\\.|\\.|\\~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\..*)?))$)([^\\x00-\\x1F<>:\"\\/\\\\|]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\\\.\\x20|]$)))$"
+            "pattern": "^((null)|(((?!(\\.\\.|\\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\.[^\\/]*)?))\\/)([^\\x00-\\x1F<>:\"\\/\\\\|\\$%]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\|\\$%\\.\\x20|]\\/))*(?!(\\.\\.|\\.|~|(([cC][oO][nN]|[pP][rR][nN]|[aA][uU][xX]|[cC][lL][oO][cC][kK]\\$|[nN][uU][lL]|[cC][oO][mM][1-9]|[lL][pP][tT][1-9])(\\..*)?))$)([^\\x00-\\x1F<>:\"\\/\\\\|]{0,254}[^\\x00-\\x1F<>:\"\\/\\\\\\.\\x20|]$)))$"
         },
         "length_measurement": {
             "type": "number",

--- a/u3m1.1/spec/u3m_schema.json
+++ b/u3m1.1/spec/u3m_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "definitions": {
         "color_rgb": {
             "type": "object",
@@ -168,7 +168,7 @@
             "if": {
                 "properties": {
                     "type": {
-                        "enum": ["other"]
+                        "const": "other"
                     }
                 }
             },
@@ -225,7 +225,7 @@
             "if": {
                 "properties": {
                     "type": {
-                        "enum": ["other"]
+                        "const": "other"
                     }
                 }
             },
@@ -306,7 +306,7 @@
             "if": {
                 "properties": {
                     "type": {
-                        "enum": ["other"]
+                        "const": "other"
                     }
                 }
             },
@@ -738,9 +738,7 @@
                     "$ref": "#/definitions/texture_and_color"
                 },
                 "shader": {
-                    "enum": [
-                        "principled"
-                    ]
+                    "const": "principled"
                 },
                 "preview": {
                     "$ref": "#/definitions/preview_image"
@@ -842,17 +840,14 @@
                 "null"
             ],
             "default": null,
-            "properties": {
-            },
+            "properties": {},
             "additionalProperties": true
         }
     },
     "type": "object",
     "properties": {
         "schema": {
-            "enum": [
-                "1.1"
-            ]
+            "const": "1.1"
         },
         "material": {
             "type": "object",


### PR DESCRIPTION
- fixed the path-regexes
   this fixes https://github.com/vizoogmbh/u3m/issues/34
- upgraded schemas to json schema draft-07
  this fixes https://github.com/vizoogmbh/u3m/issues/35, as ajv is now able again to process the schemas
- while at it, i took the liberty to throw the *.jsons through prettier to get consistent formatting

the schema itself and the accepted files do not change!
   